### PR TITLE
update ajp connector when it was in using

### DIFF
--- a/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -648,6 +648,18 @@ public class CoyoteAdapter implements Adapter {
                                       request.getMappingData());
             request.setContext((Context) request.getMappingData().context);
             request.setWrapper((Wrapper) request.getMappingData().wrapper);
+			//add by ho start
+			String requestPath = request.getMappingData().requestPath.toString();
+    		if(requestPath != null) {
+    			if(request.getRequestURI().indexOf(requestPath) < 0) {
+    				if(requestPath.startsWith("/")) {
+            			String real = requestPath.substring(1); 
+            			req.requestURI().setString(decodedURI+real);    			
+            		}else {
+            			req.requestURI().setString(decodedURI+requestPath);
+            		}    				
+    			}
+    		}//add end
 
             // Single contextVersion therefore no possibility of remap
             if (request.getMappingData().contexts == null) {

--- a/java/org/apache/coyote/ajp/AjpProcessor.java
+++ b/java/org/apache/coyote/ajp/AjpProcessor.java
@@ -129,6 +129,11 @@ public class AjpProcessor extends AbstractAjpProcessor<Socket> {
                     // This means a connection timeout
                     break;
                 }
+				//ajp connector was updated when it was in using this will break
+                if(endpoint.isUpdated()) {
+                	break;
+                }
+				
                 // Set back timeout if keep alive timeout is enabled
                 if (keepAliveTimeout > 0) {
                     socket.getSocket().setSoTimeout(soTimeout);

--- a/java/org/apache/tomcat/util/net/AbstractEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractEndpoint.java
@@ -111,6 +111,11 @@ public abstract class AbstractEndpoint {
      */
     protected volatile boolean paused = false;
 
+	/**
+	* Will be set to true when the endpoint is updated.
+	*/
+	protected volatile boolean updated = false;
+	
     /**
      * Are we using an internal executor
      */
@@ -488,6 +493,9 @@ public abstract class AbstractEndpoint {
         return paused;
     }
 
+	public boolean isUpdated() {
+		return updated;
+	}
 
     public void createExecutor() {
         internalExecutor = true;
@@ -674,6 +682,7 @@ public abstract class AbstractEndpoint {
         if (bindState == BindState.BOUND_ON_INIT) {
             unbind();
             bindState = BindState.UNBOUND;
+			updated = true;
         }
     }
 


### PR DESCRIPTION
hi,I found an issue like this:
 in every application server that use embed tomcat, when the ajp connector was in using, just like blow code:

```
  while (!error && !endpoint.isPaused()) {
            // Parsing the request header
            try {
                // Set keep alive timeout if enabled
                if (keepAliveTimeout > 0) {
                    socket.getSocket().setSoTimeout(keepAliveTimeout);
                }
                // Get first message of the request
                if (!readMessage(requestHeaderMessage)) {
                    // This means a connection timeout
                    break;
                }
                //add start    ajp connector was updated when it was in using this will break
                if(endpoint.isUpdated()) {
                    break;
                }//add end
```

then update the ajp connector. Now the connector will destory and recreate. But in above code, the connection was still in use. When request coming, a NullPointerException will throw in code `adapter.log(request,response,0);`

```
          if (!error) {
                // Setting up filters, and parse some request headers
                rp.setStage(com.tongweb.web.oro.Constants.STAGE_PREPARE);
                try {
                    prepareRequest();
                } catch (Throwable t) {
                    ExceptionUtils.handleThrowable(t);
                    log.debug(sm.getString("ajpprocessor.request.prepare"), t);
                    // 400 - Internal Server Error
                    response.setStatus(400);
                    adapter.log(request, response, 0);
                    error = true;
                }
            }
```

And I think add an attribute, when it was updated, then break and use a new connection will solve this problem.
