### PR TITLE
add a configurable constant MAX_TAG_BUFFER_CAPACITY 

### DIFF
--- a/java/org/apache/jasper/runtime/BodyContentImpl.java
+++ b/java/org/apache/jasper/runtime/BodyContentImpl.java
@@ -43,7 +43,9 @@ public class BodyContentImpl extends BodyContent {
         System.getProperty("line.separator");
     private static final boolean LIMIT_BUFFER = 
         Boolean.valueOf(System.getProperty("org.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER", "false")).booleanValue();
-    
+    public static final int MAX_TAG_BUFFER_CAPACITY =
+        Integer.valueOf(System.getProperty("org.apache.jasper.runtime.BodyContentImpl.MAX_TAG_BUFFER_CAPACITY", "32768")).intValue();
+
     private char[] cb;
     private int nextChar;
     private boolean closed;
@@ -494,7 +496,7 @@ public class BodyContentImpl extends BodyContent {
             throw new IOException();
         } else {
             nextChar = 0;
-            if (LIMIT_BUFFER && (cb.length > Constants.DEFAULT_TAG_BUFFER_SIZE)) {
+            if (LIMIT_BUFFER && (cb.length > MAX_TAG_BUFFER_CAPACITY)) {
                 cb = new char[Constants.DEFAULT_TAG_BUFFER_SIZE];
                 bufferSize = cb.length;
             }


### PR DESCRIPTION
The current threshold `Constants.DEFAULT_TAG_BUFFER_SIZE = 512` used with `LIMIT_BUFFER` is both not configurable and too small - almost any non-trivial tag will have an output larger than 512 bytes, which means using the `LIMIT_BUFFER` will end up generating lots of garbage.

This patch adds a configurable constant `MAX_TAG_BUFFER_CAPACITY` to control the threshold for clearing the buffer. The default value is 32k, but I would not mind changing it to 512 if backward compatibility is important here.
