### PR TITLE
fix StringIndexOutOfBoundsException

### DIFF
--- a/java/org/apache/jasper/JspCompilationContext.java
+++ b/java/org/apache/jasper/JspCompilationContext.java
@@ -111,7 +111,7 @@ public class JspCompilationContext {
 
         this.baseURI = jspUri.substring(0, jspUri.lastIndexOf('/') + 1);
         // hack fix for resolveRelativeURI
-        if (baseURI == null) {
+        if ("".equals(baseURI)) {
             baseURI = "/";
         } else if (baseURI.charAt(0) != '/') {
             // strip the base slash since it will be combined with the


### PR DESCRIPTION
'baseURI == null' is always 'false',  when baseURI is empty then baseURI.charAt(0) throw StringIndexOutOfBoundsException

```java
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	java.lang.String.charAt(String.java:658)
	org.apache.jasper.JspCompilationContext.<init>(JspCompilationContext.java:120)
	org.apache.jasper.JspCompilationContext.<init>(JspCompilationContext.java:98)
	org.apache.jasper.servlet.JspServletWrapper.<init>(JspServletWrapper.java:119)
	org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:388)
	org.apache.jasper.servlet.JspServlet.service(JspServlet.java:340)
	javax.servlet.http.HttpServlet.service(HttpServlet.java:729)
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	com.ofpay.rex.security.XssFilter.doFilterInternal(XssFilter.java:48)
	org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	org.springframework.web.filter.AbstractRequestLoggingFilter.doFilterInternal(AbstractRequestLoggingFilter.java:219)
	com.ofpay.commons.spring.web.RequestLoggingFilter.doFilterInternal(RequestLoggingFilter.java:121)
	org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:85)
	org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
```