### PR TITLE
Fix Java8 detection in JreMemoryLeakPreventionListener

### DIFF
--- a/java/org/apache/catalina/core/JreMemoryLeakPreventionListener.java
+++ b/java/org/apache/catalina/core/JreMemoryLeakPreventionListener.java
@@ -78,7 +78,7 @@ public class JreMemoryLeakPreventionListener implements LifecycleListener {
 
         boolean isJava8OrLater;
         try {
-            Class.forName("javax.net.ssl.SSLParameters");
+            Class.forName("java.util.Optional");
             isJava8OrLater = true;
         } catch (ClassNotFoundException e) {
             isJava8OrLater = false;


### PR DESCRIPTION
By testing for class `java.util.Optional` (Java8+) instead of class `javax.net.ssl.SSLParameters` (Java6+).

Before this patch, `IS_JAVA_8_OR_LATER` was true when running under Java6, 7 and 8.

Tested this in a new empty project with only this static block and checking the booleans by running under different JRE-versions.