### PR TITLE
Java endorsed dir java9 fix

### DIFF
--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -259,6 +259,11 @@ if [ -e "$JRE_HOME/bin/jshell" ]; then
     if [ -n "$JAVA_ENDORSED_DIRS" ]; then
         echo "Ignoring endorsed directory: $JAVA_ENDORSED_DIRS since we are in >= Java9"
     fi
+else
+    # If CATALINA_HOME/endorsed doesn't exist, use ignored prop
+    if [! -d "$CATALINA_HOME/endorsed" ]; then
+        ENDORSED_PROP=ignore.endorsed.dirs
+    fi
 fi
 
 # Uncomment the following line to make the umask available when using the

--- a/bin/catalina.sh
+++ b/bin/catalina.sh
@@ -247,15 +247,18 @@ if [ -z "$LOGGING_MANAGER" ]; then
 fi
 
 # Java 9 no longer supports the java.endorsed.dirs
-# system property. Only try to use it if
-# JAVA_ENDORSED_DIRS was explicitly set
-# or CATALINA_HOME/endorsed exists.
-ENDORSED_PROP=ignore.endorsed.dirs
-if [ -n "$JAVA_ENDORSED_DIRS" ]; then
-    ENDORSED_PROP=java.endorsed.dirs
-fi
-if [ -d "$CATALINA_HOME/endorsed" ]; then
-    ENDORSED_PROP=java.endorsed.dirs
+# system property. Don't use it if you are in a Java >= 9 runtime.
+# It doesn't matter if JAVA_ENDORSED_DIRS was explicitly set
+# just emit a warning that it is being ignored
+
+# Use existence of JRE_HOME/bin/jshell as proxy for Java >= 9 detection
+# Ref: https://git.eclipse.org/r/#/c/105865/ TomcatServerBehaviour.java
+ENDORSED_PROP=java.endorsed.dirs
+if [ -e "$JRE_HOME/bin/jshell" ]; then
+    ENDORSED_PROP=ignore.endorsed.dirs
+    if [ -n "$JAVA_ENDORSED_DIRS" ]; then
+        echo "Ignoring endorsed directory: $JAVA_ENDORSED_DIRS since we are in >= Java9"
+    fi
 fi
 
 # Uncomment the following line to make the umask available when using the

--- a/bin/setclasspath.sh
+++ b/bin/setclasspath.sh
@@ -79,10 +79,8 @@ fi
 
 # Don't override the endorsed dir if the user has set it previously
 if [ -z "$JAVA_ENDORSED_DIRS" ]; then
-  # Java 9 no longer supports the java.endorsed.dirs
-  # system property. Only try to use it if
-  # CATALINA_HOME/endorsed exists.
-  if [ -d "$CATALINA_HOME"/endorsed ]; then
+  # Set the default -Djava.endorsed.dirs argument only if <= Java9
+  if [ ! -e "$JRE_HOME/bin/jshell" ]; then
     JAVA_ENDORSED_DIRS="$CATALINA_HOME"/endorsed
   fi
 fi


### PR DESCRIPTION
* use existense of JRE_HOME/bin/jshell as the proxy for java9 detection
as per https://git.eclipse.org/r/#/c/105865/ TomcatServerBehaviour.java
* avoid setting JAVA_ENDORSED_DIRS unconditionally