### PR TITLE
[Bug 62146]: Support to add customized KeyManager like trustManagerCl…

### DIFF
--- a/java/org/apache/tomcat/util/net/AbstractEndpoint.java
+++ b/java/org/apache/tomcat/util/net/AbstractEndpoint.java
@@ -966,6 +966,12 @@ public abstract class AbstractEndpoint<S> {
         this.trustManagerClassName = trustManagerClassName;
     }
 
+    private String keyManagerClassName = null;
+    public String getKeyManagerClassName() {return keyManagerClassName;}
+    public void setKeyManagerClassName(String keyManagerClassName) {
+        this.keyManagerClassName = keyManagerClassName;
+    }
+
     private String crlFile = null;
     public String getCrlFile() {return crlFile;}
     public void setCrlFile(String crlFile) {

--- a/java/org/apache/tomcat/util/net/jsse/JSSESocketFactory.java
+++ b/java/org/apache/tomcat/util/net/jsse/JSSESocketFactory.java
@@ -631,6 +631,19 @@ public class JSSESocketFactory implements ServerSocketFactory, SSLUtil {
 
         String keystorePass = getKeystorePassword();
 
+        String className = endpoint.getKeyManagerClassName();
+        if(className != null && className.length() > 0) {
+             ClassLoader classLoader = getClass().getClassLoader();
+             Class<?> clazz = classLoader.loadClass(className);
+             if(!(KeyManager.class.isAssignableFrom(clazz))){
+                throw new InstantiationException(sm.getString(
+                        "jsse.invalidKeyManagerClassName", className));
+             }
+             Object keyManagerObject = clazz.newInstance();
+             KeyManager keyManager = (KeyManager) keyManagerObject;
+             return new KeyManager[]{ keyManager };
+        }
+
         KeyStore ks = getKeystore(keystoreType, keystoreProvider, keystorePass);
         if (keyAlias != null && !ks.isKeyEntry(keyAlias)) {
             throw new IOException(


### PR DESCRIPTION
Tomcat already support "trustManagerClassName" to let users add customized TrustManager. It's better to let Tomcat to support customized KeyManager too via "keyManagerClassName".

We're trying to let Tomcat7 support hot reloading keystore file when keystore file is get changed. One possible way is: add customized KeyManager to watch file changes and reload it then. While current Tomcat7 haven't straight-forward way to do it. If introduce a mechanism to add customized KeyManager, the problem could be resolved.